### PR TITLE
Make channelName optional when building proposals

### DIFF
--- a/internal/proposal/builder.go
+++ b/internal/proposal/builder.go
@@ -10,7 +10,6 @@ import (
 
 func New(
 	signingID *internal.SigningIdentity,
-	channelName string,
 	chaincodeName string,
 	transactionName string,
 	options ...Option,
@@ -22,7 +21,6 @@ func New(
 
 	builder := &builder{
 		signingID:       signingID,
-		channelName:     channelName,
 		chaincodeName:   chaincodeName,
 		transactionName: transactionName,
 		transactionCtx:  transactionCtx,
@@ -164,6 +162,14 @@ func stringsAsBytes(strings []string) [][]byte {
 func WithTransient(transient map[string][]byte) Option {
 	return func(b *builder) error {
 		b.transient = transient
+		return nil
+	}
+}
+
+// WithChannel specifies the name of the channel to which the transaction proposal is directed.
+func WithChannel(channelName string) Option {
+	return func(b *builder) error {
+		b.channelName = channelName
 		return nil
 	}
 }

--- a/pkg/chaincode/install/install.go
+++ b/pkg/chaincode/install/install.go
@@ -31,7 +31,6 @@ func Install(ctx context.Context, id identity.Identity, options ...Option) error
 
 type command struct {
 	signingID        *internal.SigningIdentity
-	channelName      string
 	grpcClient       peer.EndorserClient
 	grpcOptions      []grpc.CallOption
 	chaincodePackage []byte
@@ -74,7 +73,6 @@ func (c *command) signedProposal() (*peer.SignedProposal, error) {
 
 	proposal, err := proposal.New(
 		c.signingID,
-		c.channelName,
 		internal.LifecycleChaincodeName,
 		installTransactionName,
 		proposal.WithBytesArguments(argBytes),

--- a/pkg/chaincode/queryinstalled/query.go
+++ b/pkg/chaincode/queryinstalled/query.go
@@ -31,7 +31,6 @@ func Query(ctx context.Context, id identity.Identity, options ...Option) (*lifec
 
 type command struct {
 	signingID   *internal.SigningIdentity
-	channelName string
 	grpcClient  peer.EndorserClient
 	grpcOptions []grpc.CallOption
 }
@@ -79,7 +78,6 @@ func (c *command) signedProposal() (*peer.SignedProposal, error) {
 
 	proposal, err := proposal.New(
 		c.signingID,
-		c.channelName,
 		internal.LifecycleChaincodeName,
 		queryInstalledTransactionName,
 		proposal.WithBytesArguments(argBytes),


### PR DESCRIPTION
Channel name is not required for some admin operations, such as installing or querying installed chaincode on a specific peer.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>