### PR TITLE
Relocate transaction context

### DIFF
--- a/internal/proposal/builder.go
+++ b/internal/proposal/builder.go
@@ -14,7 +14,7 @@ func New(
 	transactionName string,
 	options ...Option,
 ) (*peer.Proposal, error) {
-	transactionCtx, err := internal.NewTransactionContext(signingID)
+	transactionCtx, err := newTransactionContext(signingID)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ type builder struct {
 	channelName     string
 	chaincodeName   string
 	transactionName string
-	transactionCtx  *internal.TransactionContext
+	transactionCtx  *transactionContext
 	transient       map[string][]byte
 	args            [][]byte
 }

--- a/internal/proposal/transactioncontext.go
+++ b/internal/proposal/transactioncontext.go
@@ -1,18 +1,19 @@
-package internal
+package proposal
 
 import (
 	"crypto/rand"
 	"encoding/hex"
 
+	"github.com/bestbeforetoday/fabric-admin/internal"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 )
 
-type TransactionContext struct {
+type transactionContext struct {
 	TransactionID   string
 	SignatureHeader *common.SignatureHeader
 }
 
-func NewTransactionContext(signingIdentity *SigningIdentity) (*TransactionContext, error) {
+func newTransactionContext(signingIdentity *internal.SigningIdentity) (*transactionContext, error) {
 	nonce := make([]byte, 24)
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, err
@@ -32,7 +33,7 @@ func NewTransactionContext(signingIdentity *SigningIdentity) (*TransactionContex
 		Nonce:   nonce,
 	}
 
-	transactionCtx := &TransactionContext{
+	transactionCtx := &transactionContext{
 		TransactionID:   transactionID,
 		SignatureHeader: signatureHeader,
 	}


### PR DESCRIPTION
Transaction context is only used when building proposals so move it to a non-exported member of proposal package.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>